### PR TITLE
Builder import and loading issues resolved

### DIFF
--- a/www/src/public/js/controllers/builder/main.js
+++ b/www/src/public/js/controllers/builder/main.js
@@ -150,9 +150,19 @@
                 var listCookieStr = localStorage.getItem("cln");
                 
                 if (listCookieStr) {
-                    var versionIdx = listCookieStr.indexOf("*");
-                    listVersion = Number(listCookieStr.slice(0, versionIdx));
-                    listCookieStr = listCookieStr.slice(versionIdx);
+                    var asteriskIdx = listCookieStr.indexOf("*");
+                    var tildeIdx = listCookieStr.indexOf("~");
+                    
+                    // check if list has a version number attached to string.  If so, set listVersion
+                    // this check is necessary to account for lists that have been made since the last update which are technically cln lists but do not have the new version standard applied
+                    if (asteriskIdx < tildeIdx && asteriskIdx != -1) {
+                        listVersion = Number(listCookieStr.slice(0, asteriskIdx));
+                        listCookieStr = listCookieStr.slice(asteriskIdx);
+                    }
+                    // this is used on the current cln lists in the wild without a version number attached
+                    else {
+                        listVersion = 3;
+                    }
                 }
                 else {
                     listCookieStr = localStorage.getItem("cl2");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Did extensive testing and resolved issues with importing cookie loading.  Most things were okay but found a few gotchas such as hazelnut was being included in v1 (removed now,  obviously) and there was a bug which caused it to always load all lists as v3 and remove letters from the name of lists that did not have a version number.  Also added checks to account for lists that have been made since the last update using the cln format but which do not have a version number attached.  Tested both importing and loading directly from cl2/cln cookies of both types.  In theory the way things are now done versioning should be put to bed and any future versions should just load properly, assuming they add the new version checks to the createfromstring and from list functions.

## Related Issue
This is a known bug that Stephen fixed, I was merely doing testing for him.  I resolved any issues I found to the best of my ability.

## Motivation and Context
This should hopefully resolve all issues related to versioning and importing/exporting for the future.

## How Has This Been Tested?
Explained above as well but tested importing cl1, cl2 and cln lists.  Tested both original cln lists and the new versioning style.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
