### PR TITLE
Moving hazelnut selector

### DIFF
--- a/www/src/views/builder/index.ejs
+++ b/www/src/views/builder/index.ejs
@@ -155,20 +155,20 @@
 							</div>
 							<div class="input-group input-group-sm col-8 col-sm-4 mb-3 mb-sm-0">
 								<div class="input-group-prepend">
-									<label class="input-group-text" for="hazelnutSelect">Hazelnut</label>
-								</div>
-								<select class="custom-select custom-select-sm" id="hazelnutSelect" ng-model="selectedList.baseStats.hazelnut" ng-change="saveClientSideData()" ng-model-options="{debounce:250}" ng-disabled="!showStatQuests()">
-									<option ng-value="-1">-</option>
-									<option ng-repeat="hazelnut in hazelnutList track by $index" ng-value="$index">{{::hazelnut}}</option>
-								</select>
-							</div>
-							<div class="input-group input-group-sm col-8 col-sm-4 mb-3 mb-sm-0">
-								<div class="input-group-prepend">
 									<label class="input-group-text" for="amuletSelect">Amulet</label>
 								</div>
 								<select class="custom-select custom-select-sm" id="amuletSelect" ng-model="selectedList.baseStats.amulet" ng-change="saveClientSideData()" ng-model-options="{debounce:250}" ng-disabled="!showStatQuests()">
 									<option ng-value="-1">-</option>
 									<option ng-repeat="amulet in amuletList track by $index" ng-value="$index">{{::amulet}}</option>
+								</select>
+							</div>
+							<div class="input-group input-group-sm col-8 col-sm-4 mb-3 mb-sm-0">
+								<div class="input-group-prepend">
+									<label class="input-group-text" for="hazelnutSelect">Hazelnut</label>
+								</div>
+								<select class="custom-select custom-select-sm" id="hazelnutSelect" ng-model="selectedList.baseStats.hazelnut" ng-change="saveClientSideData()" ng-model-options="{debounce:250}" ng-disabled="!showStatQuests()">
+									<option ng-value="-1">-</option>
+									<option ng-repeat="hazelnut in hazelnutList track by $index" ng-value="$index">{{::hazelnut}}</option>
 								</select>
 							</div>
 						</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The hazelnut selector is not in the right place compared to the live version. I'm moving the hazelnut selector to match the live version.

## Description
<!--- Describe your changes in detail -->
I moved section of code containing the hazelnut selector in index.ejs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#142 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To match the live version as I'm sure it will drive certain people to near insanity. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've tested this on my local machine. The hazelnut selector saves and loads normally after moving it to the proper location.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
