### PR TITLE
Fix Item Locking

### DIFF
--- a/www/src/public/js/controllers/builder/main.js
+++ b/www/src/public/js/controllers/builder/main.js
@@ -380,7 +380,7 @@
                 let isLocked = false;
                 if (listStr[0] === '.') {
                     isLocked = true;
-                    listStr.substr(1);
+                    listStr = listStr.substring(1);
                 }
                 
                 if (listStr[0] === '_') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The item locking indicator is being deleted from the string in the CreateListFromStrinV2 function.

## Description
<!--- Describe your changes in detail -->
`listStr.substring(1);` doesn't store the changed string. I changed this to `listStr = listStr.substring(1);`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#153 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I created multiple items, locked and loaded just fine. I imported a new list with locked items and it worked as intended.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
